### PR TITLE
Add support for running in binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Introduction to Python
 
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/graeme-a-stewart/python-introduction/master?filepath=presentation-insights.ipynb)
+
 This is a 120 minute lecture that introduces Python. There are
 no assumptions made at all about prior knowledge of Python, though
 any experience of programming and unix basics are handy. The
@@ -11,4 +13,5 @@ who do know basic Python will learn from it.
 
 The lecture is written as a Jupyter notebook, using the popular
 [RISE](https://github.com/damianavila/RISE) extension to present
-the material as a slideshow.
+the material as a slideshow. It can be launched using only a web
+browser by clicking the "launch binder" button above.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,12 @@
+channels:
+  - damianavila82
+  - conda-forge
+dependencies:
+  - python
+  - numpy
+  - matplotlib
+  - pandas
+  - bokeh
+  - rise
+  - pip:
+    - jupyter-contrib-nbextensions

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+jupyter contrib nbextension install --user
+jupyter nbextension enable splitcell/splitcell


### PR DESCRIPTION
I really like this tutorial (though I did have to zoom to 67% to be able to see all of the slide content)! 👍

This PR adds support for launching the notebook in binder¹ directly from the README, with support for RISE. As the README link won't work until this is merged, click this button to test it out from my branch:

[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/chrisburr/python-introduction/add-binder?filepath=presentation-insights.ipynb)

¹ In case you haven't heard of it, [Binder](https://mybinder.org/) is a convenient way to run notebooks in a web browser without installing anything.